### PR TITLE
Upgrade to swing-extras 1.9.3 for an upstream bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you're using Maven, you can just add it as a dependency:
   <dependency>
     <groupId>ca.corbett</groupId>
     <artifactId>app-extensions</artifactId>
-    <version>1.9.2</version>
+    <version>1.9.3</version>
   </dependency>
 </dependencies>
 ```
@@ -494,3 +494,6 @@ Refer also to the library's javadocs for more detailed usage information!
   - https://github.com/scorbo2/app-extensions/issues/4 - add way to unregister extensions
   - https://github.com/scorbo2/app-extensions/issues/6 - small change to extension loading
   - https://github.com/scorbo2/app-extensions/issues/8 - update the way we handle properties
+- v1.9.3 [2025-04-05]
+  - Upgrade to `swing-extras` 1.9.3 to pick up a bug fix there
+

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ca.corbett</groupId>
     <artifactId>app-extensions</artifactId>
-    <version>1.9.2</version>
+    <version>1.9.3</version>
 
     <name>app-extensions</name>
     <description>App Extensions - create dynamic extensions for Java applications</description>
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>ca.corbett</groupId>
             <artifactId>swing-extras</artifactId>
-            <version>1.9.2</version>
+            <version>1.9.3</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
No functional changes in this library. Just needed to upgrade to `swing-extras` 1.9.3 to pick up an upstream bug fix.